### PR TITLE
[review] Add Terraform directory structure for infrastructure management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,12 @@ logs/
 *.log
 game_state/
 sessions/
+
+# Terraform
+*.tfstate
+*.tfstate.*
+.terraform/
+.terraform.lock.hcl
+terraform.tfvars
+*.tfvars
+!*.tfvars.example

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,8 +68,18 @@ Monitoring (`monitoring/`)
 ruff設定 (pyproject.toml)
 
 - 行長: 100文字
-- 有効ルール: E, W, F, UP, B, I, PLR
+- 有効ルール: E, W, F, UP, B, I, C90, PLR
 - 複雑度上限: 10
+
+pytest設定
+
+- `asyncio_mode = "auto"` により async テストは自動検出
+- デフォルトでカバレッジレポート出力
+
+テスト用モックライブラリ
+
+- moto: AWS（EC2等）のモック
+- respx: httpxのモック
 
 テスト配置
 
@@ -97,3 +107,29 @@ ruff設定 (pyproject.toml)
 - HTTP通信はhttpxを使用（タイムアウト10秒推奨）
 - データ構造はpydantic BaseModelで定義
 - すべての関数に型アノテーションを付ける
+
+## インフラストラクチャ
+
+Terraformによるインフラ管理（`infra/terraform/`）
+
+```bash
+cd infra/terraform/environments/dev  # or prod
+terraform init
+terraform plan
+terraform apply
+```
+
+環境分離
+
+- `environments/dev/`: 開発環境
+- `environments/prod/`: 本番環境
+- `modules/`: 再利用可能モジュール
+
+コード品質
+
+```bash
+terraform fmt -recursive
+terraform validate
+```
+
+詳細は `infra/terraform/README.md` を参照。

--- a/README.md
+++ b/README.md
@@ -33,21 +33,25 @@
 
 ## プロジェクト構造
 
-```text
-gameserver_pilot/
-├── __init__.py
+```tree
+gameserver_pilot/          # アプリケーションコード
 ├── bot.py                 # Discord Bot メイン
 ├── config.py              # 設定（pydantic-settings）
 ├── cloud/                 # クラウドプロバイダー
-│   ├── __init__.py
 │   ├── base.py           # 抽象クラス CloudProvider
 │   ├── ec2.py            # AWS EC2実装
 │   └── mock.py           # 開発用モック
 └── monitors/              # プレイヤー監視
-    ├── __init__.py
     ├── base.py           # 抽象クラス PlayerMonitor
     ├── tshock.py         # TShock REST API監視
     └── logfile.py        # ログファイル監視
+
+infra/                     # インフラストラクチャ
+└── terraform/
+    ├── environments/
+    │   ├── dev/          # 開発環境
+    │   └── prod/         # 本番環境
+    └── modules/          # 再利用可能モジュール
 ```
 
 ## ドキュメント
@@ -56,6 +60,7 @@ gameserver_pilot/
 
 - [アーキテクチャ](./docs/architecture.md) - システム構成
 - [Beszel監視設計](./docs/beszel-monitoring.md) - リソース監視の設計
+- [Terraformインフラ](./infra/terraform/README.md) - AWS インフラ構成
 
 ## セットアップ
 

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,72 @@
+# Terraform Infrastructure
+
+gameserver-pilot のインフラストラクチャを管理する Terraform 構成。
+
+## ディレクトリ構成
+
+```tree
+terraform/
+├── environments/
+│   ├── dev/      # 開発環境
+│   └── prod/     # 本番環境
+└── modules/      # 再利用可能モジュール
+```
+
+## セットアップ
+
+### 前提条件
+
+- Terraform >= 1.0
+- AWS CLI（認証設定済み）
+
+### 初期化
+
+```bash
+cd environments/dev  # or prod
+cp terraform.tfvars.example terraform.tfvars
+# terraform.tfvars を編集
+
+terraform init
+terraform plan
+terraform apply
+```
+
+## リモートステート設定
+
+S3バケットとDynamoDBテーブルを作成後、`backend.tf` のコメントを解除してください。
+
+```bash
+# S3バケット作成（例）
+aws s3api create-bucket \
+  --bucket gameserver-pilot-tfstate \
+  --region ap-northeast-1 \
+  --create-bucket-configuration LocationConstraint=ap-northeast-1
+
+# DynamoDBテーブル作成（例）
+aws dynamodb create-table \
+  --table-name gameserver-pilot-tfstate-lock \
+  --attribute-definitions AttributeName=LockID,AttributeType=S \
+  --key-schema AttributeName=LockID,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST \
+  --region ap-northeast-1
+```
+
+## 環境の違い
+
+| 項目 | dev | prod |
+|------|-----|------|
+| tfstate key | `dev/terraform.tfstate` | `prod/terraform.tfstate` |
+| default_tags.Environment | `dev` | `prod` |
+
+## TODO
+
+- [ ] S3バケット・DynamoDBテーブル作成（リモートステート用）
+- [ ] `backend.tf` のコメント解除
+- [ ] `modules/ec2-gameserver` モジュール作成
+  - EC2インスタンス
+  - セキュリティグループ
+  - IAMロール（必要に応じて）
+- [ ] `modules/networking` モジュール作成（必要に応じて）
+  - VPC
+  - サブネット
+  - インターネットゲートウェイ

--- a/infra/terraform/environments/dev/backend.tf
+++ b/infra/terraform/environments/dev/backend.tf
@@ -1,0 +1,11 @@
+# Uncomment after creating the S3 bucket and DynamoDB table for state management
+#
+# terraform {
+#   backend "s3" {
+#     bucket         = "gameserver-pilot-tfstate"
+#     key            = "dev/terraform.tfstate"
+#     region         = "ap-northeast-1"
+#     encrypt        = true
+#     dynamodb_table = "gameserver-pilot-tfstate-lock"
+#   }
+# }

--- a/infra/terraform/environments/dev/backend.tf
+++ b/infra/terraform/environments/dev/backend.tf
@@ -1,4 +1,5 @@
 # Uncomment after creating the S3 bucket and DynamoDB table for state management
+# Note: region must match var.aws_region (backend config cannot use variables)
 #
 # terraform {
 #   backend "s3" {

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -1,0 +1,13 @@
+# Game Server Infrastructure - Development Environment
+#
+# Usage:
+#   terraform init
+#   terraform plan
+#   terraform apply
+#
+# Add module calls here as infrastructure grows:
+#
+# module "gameserver" {
+#   source = "../../modules/ec2-gameserver"
+#   # ...
+# }

--- a/infra/terraform/environments/dev/outputs.tf
+++ b/infra/terraform/environments/dev/outputs.tf
@@ -1,0 +1,7 @@
+# Output values
+#
+# Example:
+# output "instance_id" {
+#   description = "EC2 instance ID"
+#   value       = module.gameserver.instance_id
+# }

--- a/infra/terraform/environments/dev/provider.tf
+++ b/infra/terraform/environments/dev/provider.tf
@@ -15,7 +15,7 @@ provider "aws" {
   default_tags {
     tags = {
       Project     = "gameserver-pilot"
-      Environment = "dev"
+      Environment = var.environment
       ManagedBy   = "terraform"
     }
   }

--- a/infra/terraform/environments/dev/provider.tf
+++ b/infra/terraform/environments/dev/provider.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = "gameserver-pilot"
+      Environment = "dev"
+      ManagedBy   = "terraform"
+    }
+  }
+}

--- a/infra/terraform/environments/dev/terraform.tfvars.example
+++ b/infra/terraform/environments/dev/terraform.tfvars.example
@@ -1,0 +1,4 @@
+# Copy this file to terraform.tfvars and fill in the values
+# terraform.tfvars is ignored by git
+
+aws_region = "ap-northeast-1"

--- a/infra/terraform/environments/dev/variables.tf
+++ b/infra/terraform/environments/dev/variables.tf
@@ -1,0 +1,5 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-1"
+}

--- a/infra/terraform/environments/dev/variables.tf
+++ b/infra/terraform/environments/dev/variables.tf
@@ -3,3 +3,9 @@ variable "aws_region" {
   type        = string
   default     = "ap-northeast-1"
 }
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "dev"
+}

--- a/infra/terraform/environments/prod/backend.tf
+++ b/infra/terraform/environments/prod/backend.tf
@@ -1,4 +1,5 @@
 # Uncomment after creating the S3 bucket and DynamoDB table for state management
+# Note: region must match var.aws_region (backend config cannot use variables)
 #
 # terraform {
 #   backend "s3" {

--- a/infra/terraform/environments/prod/backend.tf
+++ b/infra/terraform/environments/prod/backend.tf
@@ -1,0 +1,11 @@
+# Uncomment after creating the S3 bucket and DynamoDB table for state management
+#
+# terraform {
+#   backend "s3" {
+#     bucket         = "gameserver-pilot-tfstate"
+#     key            = "prod/terraform.tfstate"
+#     region         = "ap-northeast-1"
+#     encrypt        = true
+#     dynamodb_table = "gameserver-pilot-tfstate-lock"
+#   }
+# }

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -1,0 +1,13 @@
+# Game Server Infrastructure - Production Environment
+#
+# Usage:
+#   terraform init
+#   terraform plan
+#   terraform apply
+#
+# Add module calls here as infrastructure grows:
+#
+# module "gameserver" {
+#   source = "../../modules/ec2-gameserver"
+#   # ...
+# }

--- a/infra/terraform/environments/prod/outputs.tf
+++ b/infra/terraform/environments/prod/outputs.tf
@@ -1,0 +1,7 @@
+# Output values
+#
+# Example:
+# output "instance_id" {
+#   description = "EC2 instance ID"
+#   value       = module.gameserver.instance_id
+# }

--- a/infra/terraform/environments/prod/provider.tf
+++ b/infra/terraform/environments/prod/provider.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = "gameserver-pilot"
+      Environment = "prod"
+      ManagedBy   = "terraform"
+    }
+  }
+}

--- a/infra/terraform/environments/prod/provider.tf
+++ b/infra/terraform/environments/prod/provider.tf
@@ -15,7 +15,7 @@ provider "aws" {
   default_tags {
     tags = {
       Project     = "gameserver-pilot"
-      Environment = "prod"
+      Environment = var.environment
       ManagedBy   = "terraform"
     }
   }

--- a/infra/terraform/environments/prod/terraform.tfvars.example
+++ b/infra/terraform/environments/prod/terraform.tfvars.example
@@ -1,0 +1,4 @@
+# Copy this file to terraform.tfvars and fill in the values
+# terraform.tfvars is ignored by git
+
+aws_region = "ap-northeast-1"

--- a/infra/terraform/environments/prod/variables.tf
+++ b/infra/terraform/environments/prod/variables.tf
@@ -1,0 +1,5 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-1"
+}

--- a/infra/terraform/environments/prod/variables.tf
+++ b/infra/terraform/environments/prod/variables.tf
@@ -3,3 +3,9 @@ variable "aws_region" {
   type        = string
   default     = "ap-northeast-1"
 }
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "prod"
+}


### PR DESCRIPTION
## 変更の概要

EC2インスタンス管理用のTerraformディレクトリ構成を追加しました。

## 主な変更点

- `infra/terraform/` ディレクトリ構成を作成（dev/prod環境分離）
- 各環境にスケルトンファイルを配置（provider.tf, backend.tf, variables.tf等）
- `.gitignore` にTerraform関連エントリを追加

## 他、軽微な修正

- README.mdのプロジェクト構造に`infra/`を追加
- README.mdのドキュメントセクションにインフラへのリンクを追加
- CLAUDE.mdにインフラセクションとpytest/ruff設定の補足を追加

## 変更の背景

IaCによるインフラ管理を導入するにあたり、ディレクトリ構成を先に決定しました。ベストプラクティスに基づき、環境ごとに分離した構成を採用しています。

## 補足

本PRはディレクトリ構成の決定のみです。実際のリソース定義（EC2モジュール等）は後続PRで対応します。残作業は`infra/terraform/README.md`のTODOセクションに記載しています。